### PR TITLE
Fix an action shadowing warning in the deburster

### DIFF
--- a/AXI/AXI4_Utils.bsv
+++ b/AXI/AXI4_Utils.bsv
@@ -336,13 +336,13 @@ module mkSerialiser #(AXI4_Master#(a, b, c, d, e, f, g, h) m)
 
   (* mutually_exclusive = "takeR, takeB" *)
 
-  rule takeB;
+  rule takeB (state[1] == WAITING);
     let bFlit <- get(slv.b);
     m.b.put(bFlit);
     state[1] <= IDLE;
   endrule
 
-  rule takeR;
+  rule takeR (state[1] == WAITING);
     let rFlit <- get(slv.r);
     m.r.put(rFlit);
     if (rFlit.rlast) state[1] <= IDLE;


### PR DESCRIPTION
@PeterRugg can you check that you are happy with this one please?

(This can be tested for example in [here](https://github.com/CTSRD-CHERI/BlueStuff/blob/master/examples/Example-AXI4-Deburst.bsv). You can run `make simExample-AXI4-Deburst` to check the output.)